### PR TITLE
fix: remove readiness and liveliness probes for Agent

### DIFF
--- a/helm-chart/templates/deployment.yaml
+++ b/helm-chart/templates/deployment.yaml
@@ -43,14 +43,6 @@ spec:
             - name: http
               containerPort: {{ .Values.service.port }}
               protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /
-              port: http
-          readinessProbe:
-            httpGet:
-              path: /
-              port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}


### PR DESCRIPTION
Currently the Helm chart for the Checkly Agent contains a readiness and liveliness probe. The Agent doesn't actually contain a health endpoint, though, so Kubernetes continues restarting the Agent in a loop. This PR simply removes the readiness and liveliness probe. 

Tested locally in Minikube.